### PR TITLE
Asking the user if they want to update kali package list before installing

### DIFF
--- a/kali-setup
+++ b/kali-setup
@@ -8,6 +8,9 @@ def read_deps_file(deps_file):
 
 if __name__ == '__main__':
 
+    if raw_input('Do you want update your package list ("apt-get update")? [y/N]').lower() == 'y':
+        print '[*] Downloading package lists from kali repositories'
+        os.system('apt-get update')
 
     print '[*] Installing Kali dependencies...'
     os.system('apt-get install %s' % read_deps_file('kali-dependencies.txt'))


### PR DESCRIPTION
The issue is that If you don't do `apt-get update` before installing, and the package list haven't been updated for a while. The kali-setup script may fail due to missing packages. The readme mentions that you have to do `apt-get update` before installing, but not everyone reads the readme. 