### PR TITLE
Calculate correct MSCHAPv2 challenge hash when username includes domain

### DIFF
--- a/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
+++ b/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
@@ -332,11 +332,6 @@ static void eap_mschapv2_process_response(struct eap_sm *sm,
 	wpa_printf(MSG_MSGDUMP, "EAP-MSCHAPV2: Flags 0x%x", flags);
 	wpa_hexdump_ascii(MSG_MSGDUMP, "EAP-MSCHAPV2: Name", name, name_len);
 
-	// wpe
-	challenge_hash(peer_challenge, data->auth_challenge, name, name_len, wpe_challenge_hash);
-	wpe_log_chalresp("mschapv2", name, name_len, wpe_challenge_hash, 8, nt_response, 24);
- 
-
 	buf = os_malloc(name_len * 4 + 1);
 	if (buf) {
 		printf_encode(buf, name_len * 4 + 1, name, name_len);
@@ -366,6 +361,10 @@ static void eap_mschapv2_process_response(struct eap_sm *sm,
 			break;
 		}
 	}
+
+	// wpe
+	challenge_hash(peer_challenge, data->auth_challenge, user, user_len, wpe_challenge_hash);
+	wpe_log_chalresp("mschapv2", user, user_len, wpe_challenge_hash, 8, nt_response, 24);
 
 #ifdef CONFIG_TESTING_OPTIONS
 	{

--- a/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
+++ b/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
@@ -364,7 +364,7 @@ static void eap_mschapv2_process_response(struct eap_sm *sm,
 
 	// wpe
 	challenge_hash(peer_challenge, data->auth_challenge, user, user_len, wpe_challenge_hash);
-	wpe_log_chalresp("mschapv2", user, user_len, wpe_challenge_hash, 8, nt_response, 24);
+	wpe_log_chalresp("mschapv2", name, name_len, user, user_len, wpe_challenge_hash, 8, nt_response, 24);
 
 #ifdef CONFIG_TESTING_OPTIONS
 	{

--- a/hostapd-eaphammer/src/eap_server/eap_server_ttls.c
+++ b/hostapd-eaphammer/src/eap_server/eap_server_ttls.c
@@ -607,7 +607,7 @@ static void eap_ttls_process_phase2_chap(struct eap_sm *sm,
 	chap_md5(password[0], sm->user->password, sm->user->password_len,
 		 challenge, challenge_len, hash);
 
-	wpe_log_chalresp("eap-ttls/chap", sm->identity, sm->identity_len, challenge, challenge_len, password, password_len);
+	wpe_log_chalresp("eap-ttls/chap",sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, password, password_len);
 
 	if ((eaphammer_global_conf.always_return_success) || (os_memcmp(hash, password + 1, EAP_TTLS_CHAP_PASSWORD_LEN) == 0)) {
 		wpa_printf(MSG_DEBUG, "EAP-TTLS/CHAP: Correct user password");
@@ -677,7 +677,7 @@ static void eap_ttls_process_phase2_mschap(struct eap_sm *sm,
 		nt_challenge_response(challenge, sm->user->password,
 				      sm->user->password_len, nt_response);
 
-	wpe_log_chalresp("eap-ttls/mschap", sm->identity, sm->identity_len, challenge, challenge_len, response + 2 + 24, 24);
+	wpe_log_chalresp("eap-ttls/mschap",sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, response + 2 + 24, 24);
 
 	if ((eaphammer_global_conf.always_return_success) || (os_memcmp(nt_response, response + 2 + 24, 24) == 0)) {
 		wpa_printf(MSG_DEBUG, "EAP-TTLS/MSCHAP: Correct response");
@@ -788,7 +788,7 @@ static void eap_ttls_process_phase2_mschapv2(struct eap_sm *sm,
 	rx_resp = response + 2 + EAP_TTLS_MSCHAPV2_CHALLENGE_LEN + 8;
 	
 	challenge_hash(peer_challenge, auth_challenge, username, username_len, wpe_challenge_hash);
-	wpe_log_chalresp("eap-ttls/mschapv2", username, username_len, wpe_challenge_hash, 8, rx_resp, 24);
+	wpe_log_chalresp("eap-ttls/mschapv2", sm->identity, sm->identity_len, username, username_len, wpe_challenge_hash, 8, rx_resp, 24);
 
 #ifdef CONFIG_TESTING_OPTIONS
 	{

--- a/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
+++ b/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
@@ -98,30 +98,35 @@ void eaphammer_write_fifo(const u8 *username,
 }
 // end eaphammer fifo
 
-void wpe_log_chalresp(char *type, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len) {
+void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len) {
     time_t nowtime;
     int x; 
 
     nowtime = time(NULL);
 
     wpe_log_file_and_stdout("\n\n%s: %s", type, ctime(&nowtime));
-    wpe_log_file_and_stdout("\t username:\t\t");
+    wpe_log_file_and_stdout("\t domain\\username:\t\t");
+    for (x=0; x<full_username_len; x++) {
+        wpe_log_file_and_stdout("%c",full_username[x]);
+	}
+    wpe_log_file_and_stdout("\n");
+    wpe_log_file_and_stdout("\t username:\t\t\t");
     for (x=0; x<username_len; x++) {
         wpe_log_file_and_stdout("%c",username[x]);
 	}
     wpe_log_file_and_stdout("\n");
 
-    wpe_log_file_and_stdout("\t challenge:\t\t");
+    wpe_log_file_and_stdout("\t challenge:\t\t\t");
     for (x=0; x<challenge_len - 1; x++) {
         wpe_log_file_and_stdout("%02x:",challenge[x]);
 	}
     wpe_log_file_and_stdout("%02x\n",challenge[x]);
 
-    wpe_log_file_and_stdout("\t response:\t\t");
+    wpe_log_file_and_stdout("\t response:\t\t\t");
     for (x=0; x<response_len - 1; x++) {
         wpe_log_file_and_stdout("%02x:",response[x]);
 	}
-    wpe_log_file_and_stdout("%02x\n",response[x]);
+    wpe_log_file_and_stdout("%02x\n\n",response[x]);
 
 	// begin eaphammer
 	if ( eaphammer_global_conf.use_autocrack != 0 ) {
@@ -136,7 +141,7 @@ void wpe_log_chalresp(char *type, const u8 *username, size_t username_len, const
 	// end eaphammer
 
     if (strncmp(type, "mschapv2", 8) == 0 || strncmp(type, "eap-ttls/mschapv2", 17) == 0) {
-        wpe_log_file_and_stdout("\t jtr NETNTLM:\t\t");
+        wpe_log_file_and_stdout("\t jtr NETNTLM:\t\t\t");
         for (x=0; x<username_len; x++)
             wpe_log_file_and_stdout("%c",username[x]);
         wpe_log_file_and_stdout(":$NETNTLM$");
@@ -146,12 +151,12 @@ void wpe_log_chalresp(char *type, const u8 *username, size_t username_len, const
         wpe_log_file_and_stdout("$");
         for (x=0; x<response_len; x++)
             wpe_log_file_and_stdout("%02x",response[x]);
-        wpe_log_file_and_stdout("\n");
+        wpe_log_file_and_stdout("\n\n");
     }
 
 	// begin eaphammer
     if (strncmp(type, "mschapv2", 8) == 0 || strncmp(type, "eap-ttls/mschapv2", 17) == 0) {
-        wpe_log_file_and_stdout("\t hashcat NETNTLM:\t");
+        wpe_log_file_and_stdout("\t hashcat NETNTLM:\t\t");
         for (x=0; x<username_len; x++)
             wpe_log_file_and_stdout("%c",username[x]);
         wpe_log_file_and_stdout("::::");
@@ -162,7 +167,7 @@ void wpe_log_chalresp(char *type, const u8 *username, size_t username_len, const
 
         for (x=0; x<challenge_len; x++)
             wpe_log_file_and_stdout("%02x",challenge[x]);
-        wpe_log_file_and_stdout("\n");
+        wpe_log_file_and_stdout("\n\n\n");
     }
 	
 

--- a/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.h
+++ b/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.h
@@ -40,5 +40,5 @@ extern struct eaphammer_global_config eaphammer_global_conf;
 void wpe_log_file_and_stdout(char const *fmt, ...);
 void eaphammer_write_fifo(const u8 *username, size_t username_len, // eaphammer 
 			const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len); // eaphammer
-void wpe_log_chalresp(char *type, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len);
+void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len);
 void wpe_log_basic(char *type, const u8 *username, size_t username_len, const u8 *password, size_t password_len);


### PR DESCRIPTION
This fixes a bug where MSCHAPv2 challenge hashes are incorrectly calculated if the user name has a domain name prepended.