### PR TITLE
Added Interface class in core/interface.py (this time with version bump)

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,3 +7,4 @@ import payloads
 import autocrack
 import services
 import cli
+import interface

--- a/core/interface.py
+++ b/core/interface.py
@@ -1,0 +1,49 @@
+import utils
+import os
+import time
+
+class Interface(object):
+    
+    def __init__(self, interface):
+        self.interface = interface
+
+    def up(self):
+        print '[*] Bringing %s up...' % self.interface
+        os.system('ip link set %s up' % self.interface)
+        print '[*] Complete!'
+        time.sleep(.5)
+
+    def down(self):
+        print '[*] Bringing %s down...' % self.interface
+        os.system('ip link set %s down' % self.interface)
+        print '[*] Complete!'
+        time.sleep(.5)
+        
+    def mode_monitor(self):
+        print '[*] Placing %s into monitor mode...' % self.interface
+        os.system('iw dev %s set type monitor' % self.interface)
+        print '[*] Complete!'
+        time.sleep(.5)
+    
+    def mode_managed(self):
+        print '[*] Placing %s into managed mode...' % self.interface
+        os.system('iw dev %s set type managed' % self.interface)
+        print '[*] Complete!'
+        time.sleep(.5)
+
+    def nm_off(self):
+        print '[*] Reticulating radio frequency splines...'
+        os.system('nmcli device set %s managed no' % self.interface)
+        utils.sleep_bar(1, '[*] Using nmcli to tell NetworkManager not to manage %s...' % self.interface) 
+        print '[*] Success: %s no longer controlled by NetworkManager.' % self.interface
+
+    def nm_on(self):
+        os.system('nmcli device set %s managed yes' % self.interface)
+        utils.sleep_bar(1, '[*] Using nmcli to give NetworkManager control of %s...' % self.interface)
+        print '[*] Success: %s is now managed by NetworkManager.' % self.interface
+
+    def set_ip_and_netmask(self, ip, netmask):
+        os.system('ifconfig %s %s netmask %s' % (self.interface, ip, netmask))
+
+    def __str__(self):
+        return self.interface

--- a/core/utils.py
+++ b/core/utils.py
@@ -38,22 +38,6 @@ def sleep_bar(sleep_time, text=''):
 
     print
 
-        
-class nmcli(object):
-
-    @staticmethod
-    def set_managed(iface):
-        os.system('nmcli device set %s managed yes' % iface)
-        sleep_bar(1, '[*] Using nmcli to give NetworkManager control of %s...' % iface)
-        print '[*] Success: %s is now managed by NetworkManager.' % iface
-
-    @staticmethod
-    def set_unmanaged(iface):
-        print '[*] Reticulating radio frequency splines...'
-        os.system('nmcli device set %s managed no' % iface)
-        sleep_bar(1, '[*] Using nmcli to tell NetworkManager not to manage %s...' % iface) 
-        print '[*] Success: %s no longer controlled by NetworkManager.' % iface
-
 def set_ipforward(value):
 
     with open(settings.dict['core']['eaphammer']['general']['proc_ipforward'], 'w') as fd:

--- a/eaphammer
+++ b/eaphammer
@@ -53,18 +53,25 @@ def cert_wizard():
 def hostile_portal():
     global responder
 
+    use_autocrack = options['autocrack']
+    wordlist = options['wordlist']
+    interface = core.interface.Interface(options['interface'])
+    use_pivot = options['pivot']
+    save_config = options['save_config']
+
     try:
         utils.Iptables.save_rules()
     
         # start autocrack if enabled
-        if options['autocrack']:
+        if use_autocrack:
 
             autocrack = Autocrack.get_instance()
-            autocrack.configure(wordlist=options['wordlist'])
+            autocrack.configure(wordlist=wordlist)
             autocrack.start()
+            time.sleep(4)
 
         # prepare environment
-        utils.nmcli.set_unmanaged(options['interface'])
+        interface.nm_off()
         utils.set_ipforward(1)
 
         # write hostapd config file to tmp directory
@@ -76,12 +83,11 @@ def hostile_portal():
         hostapd.start()
 
         # configure routing 
-        os.system('ifconfig %s 10.0.0.1 netmask 255.255.255.0' %\
-                                                         options['interface'])
+        interface.set_ip_and_netmask('10.0.0.1', '255.255.255.0')
         os.system('route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1')
 
         # configure dnsmasq
-        conf_manager.dnsmasq_captive_portal_cnf.configure(interface=options['interface']) 
+        conf_manager.dnsmasq_captive_portal_cnf.configure(interface=str(interface))
         services.Dnsmasq.hardstart('-C %s 2>&1' % settings.dict['paths']['dnsmasq']['conf'])
 
         # start RedirectServer
@@ -90,7 +96,7 @@ def hostile_portal():
         rs.start()
 
         # start Responder
-        if options['pivot']:
+        if use_pivot:
 
             print '[*] Pivot mode activated. Rogue SMB server disabled.'
             print ('[*] Run payload_generator to '
@@ -103,7 +109,7 @@ def hostile_portal():
             settings.dict['core']['responder']['Responder Core']['SMB'] = 'On'
 
         resp = responder.Responder.get_instance()
-        resp.configure(interface=options['interface'])
+        resp.configure(interface=str(interface))
         resp.start()
 
         # set iptables policy, flush all tables for good measure
@@ -112,8 +118,8 @@ def hostile_portal():
         utils.Iptables.flush('nat')
 
         # use iptables to redirect all DNS and HTTP(S) traffic to PHY
-        utils.Iptables.route_dns2_addr('10.0.0.1', options['interface'])
-        utils.Iptables.route_http2_addr('10.0.0.1', options['interface'])
+        utils.Iptables.route_dns2_addr('10.0.0.1', interface)
+        utils.Iptables.route_http2_addr('10.0.0.1', interface)
 
         # pause execution until user quits
         raw_input('\n\nPress enter to quit...\n\n')
@@ -122,11 +128,11 @@ def hostile_portal():
         services.Dnsmasq.kill()
         rs.stop()
         resp.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
 
@@ -138,7 +144,7 @@ def hostile_portal():
         utils.Iptables.restore_rules()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
 
     except KeyboardInterrupt:
@@ -147,11 +153,11 @@ def hostile_portal():
         services.Dnsmasq.kill()
         rs.stop()
         resp.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
         
@@ -163,9 +169,14 @@ def hostile_portal():
         utils.Iptables.restore_rules()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
 def captive_portal():
+
+    interface = core.interface.Interface(options['interface'])
+    use_autocrack = options['autocrack']
+    wordlist = options['wordlist']
+    save_config = options['save_config']
 
     try:
 
@@ -173,13 +184,13 @@ def captive_portal():
 
         # prepare environment
         utils.set_ipforward(1)
-        utils.nmcli.set_unmanaged(options['interface'])
+        interface.nm_off()
 
         # start autocrack if enabled
-        if options['autocrack']:
+        if use_autocrack:
 
             autocrack = Autocrack.get_instance()
-            autocrack.configure(wordlist=options['wordlist'])
+            autocrack.configure(wordlist=wordlist)
             autocrack.start()
 
         # write hostapd config file to tmp directory
@@ -191,12 +202,11 @@ def captive_portal():
         hostapd.start()
 
         # configure routing 
-        os.system('ifconfig %s 10.0.0.1 netmask 255.255.255.0' %\
-                                                     options['interface'])
+        interface.set_ip_and_netmask('10.0.0.1', '255.255.255.0')
         os.system('route add -net 10.0.0.0 netmask 255.255.255.0 gw 10.0.0.1')
 
         # configure dnsmasq
-        conf_manager.dnsmasq_captive_portal_cnf.configure(interface=options['interface'])
+        conf_manager.dnsmasq_captive_portal_cnf.configure(interface=str(interface))
         services.Dnsmasq.hardstart('-C %s 2>&1' % settings.dict['paths']['dnsmasq']['conf'])
 
         # start httpd
@@ -208,8 +218,8 @@ def captive_portal():
         utils.Iptables.flush('nat')
 
         # use iptables to redirect all DNS and HTTP(S) traffic to PHY
-        utils.Iptables.route_dns2_addr('10.0.0.1', options['interface'])
-        utils.Iptables.route_http2_addr('10.0.0.1', options['interface'])
+        utils.Iptables.route_dns2_addr('10.0.0.1', interface)
+        utils.Iptables.route_http2_addr('10.0.0.1', interface)
         
         # pause execution until user quits
         raw_input('\n\nPress enter to quit...\n\n')
@@ -217,11 +227,11 @@ def captive_portal():
         hostapd.stop()
         services.Dnsmasq.kill()
         services.Httpd.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
         
@@ -233,18 +243,18 @@ def captive_portal():
         utils.Iptables.restore_rules()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
     except KeyboardInterrupt:
 
         hostapd.stop()
         services.Dnsmasq.kill()
         services.Httpd.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
         
@@ -256,22 +266,27 @@ def captive_portal():
         utils.Iptables.restore_rules()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
 def reap_creds():
+
+    interface = core.interface.Interface(options['interface'])
+    use_autocrack = options['autocrack']
+    wordlist = options['wordlist']
+    save_config = options['save_config']
 
     try:
 
         utils.Iptables.save_rules()
 
         # start autocrack if enabled
-        if options['autocrack']:
+        if use_autocrack:
 
             autocrack = Autocrack.get_instance()
-            autocrack.configure(wordlist=options['wordlist'])
+            autocrack.configure(wordlist=wordlist)
             autocrack.start()
 
-        utils.nmcli.set_unmanaged(options['interface'])
+        interface.nm_off()
 
         # write hostapd config file to tmp directory
         hostapd_conf = HostapdConfig(settings, options)
@@ -285,30 +300,30 @@ def reap_creds():
         raw_input('\n\nPress enter to quit...\n\n')
 
         hostapd.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
     except KeyboardInterrupt:
 
         hostapd.stop()
-        if options['autocrack']:
+        if use_autocrack:
             autocrack.stop()
 
         # remove hostapd conf file from tmp directory
-        if options['save_config']:
+        if save_config:
             hostapd_conf.save()
         hostapd_conf.remove()
 
         # cleanly allow network manager to regain control of interface
-        utils.nmcli.set_managed(options['interface'])
+        interface.nm_on()
 
 def save_config_only():
 
@@ -337,7 +352,6 @@ if __name__ == '__main__':
 
     print_banner()
 
-    #options = set_options()
     options = core.cli.set_options()
 
     if options['debug']:

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,3 +1,3 @@
 from settings import settings
 
-__version__ = '0.1.6'
+__version__ = '0.2.6'


### PR DESCRIPTION
Added Interface class in core/interface.py that is now being used to manage the state of network interfaces. Note that the Interface class does not maintain a state itself at this time, other than the name of the interface that it is currently managing.

Additionally, within the main eaphammer file, command line options are now assigned to variables at the top of each function, rather than accessed directly from the global options dictionary. This change was made to improve code clarity.

Version bump to 0.2.6.