### PR TITLE
eaphammer script change

### DIFF
--- a/eaphammer
+++ b/eaphammer
@@ -22,7 +22,7 @@ from core.servers.redirect_server import RedirectServer
 from core.wpa_supplicant import WPA_Supplicant
 from core.wpa_supplicant_conf import WPASupplicantConf
 from datetime import datetime
-from queue import Queue
+from multiprocessing import Queue
 from settings import settings, __version__
 from threading import Thread
 


### PR DESCRIPTION
Currently on kali.linux.2018.4 release install.

from queue import Queue doesn't work if it's on python 2.7.
proposed change to the following:

from multiprocessing import Queue

This worked for me.