### PR TITLE
Add Support for OWE, OWE Transition Mode

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -122,3 +122,6 @@ Hostapd now compiled with support for OWE, WPA3, and 802.11ax. However, these pr
 
 1.4.0 - Gabriel Ryan <gryan@specterops.io>
 Added support for advanced karma attacks: known beacon (credit: Census Labs) and loud mode (credit: Sensepost). Added support for 802.11w (Protected Management Frames).
+
+1.5.0 - Gabriel Ryan <gryan@specterops.io>
+Added support for rogue AP attacks against networks that use OWE and OWE Transition Mode.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Features
 - Fast and automated PMKID attacks against PSK networks using hcxtools
 - Password spraying across multiple usernames against a single ESSID
 
-### New (as of Version 1.4.0)(latest): 
+### New (as of Version 1.5.0)(latest): 
+EAPHammer now supports rogue AP attacks against OWE and OWE-Transition mode networks.
+
+### PMF (added as of Version 1.4.0)
 EAPHammer now supports 802.11w (Protected Management Frames), Loud Karma attacks, and Known Beacon attacks (documentation coming soon).
 
 ### GTC Downgrade Attacks

--- a/__version__.py
+++ b/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '1.4.0'
+__version__ = '1.5.0'
 __codename__ = 'Unrelenting Force'
 __author__ = '@s0lst1c3'
 __contact__ = 'gryan@specterops.io'

--- a/core/cli.py
+++ b/core/cli.py
@@ -10,6 +10,7 @@ from cert_wizard import cert_utils
 from pathlib import Path
 
 BASIC_OPTIONS = [
+
     'cert_wizard',
     'reap_creds',
     'pmkid',
@@ -20,6 +21,8 @@ BASIC_OPTIONS = [
     'essid',
     'bssid',
     'pmf',
+    'owe_transition_bssid',
+    'owe_transition_ssid',
     'channel',
     'hw_mode',
     'cloaking',
@@ -365,7 +368,13 @@ def set_options():
     access_point_group.add_argument('--auth',
                                     dest='auth',
                                     type=str,
-                                    choices=['open', 'wpa'],
+                                    choices=[
+                                        'open',
+                                        'wpa',
+                                        'owe',
+                                        'owe-transition',
+                                        'owe-psk',
+                                    ],
                                     default=None,
                                     help='Specify authentication mechanism '
                                          '(hostile and captive portal '
@@ -602,6 +611,24 @@ def set_options():
                            default=None,
                            help='Set WPA version. (default: 2)')
 
+    owe_transition_group = parser.add_argument_group(
+                        'OWE Transition Mode Options',
+                        ('Only applicable if --auth '
+                            'owe-transition is used'),
+    )
+
+    owe_transition_group.add_argument('--transition-bssid',
+                        dest='owe_transition_bssid',
+                        type=str,
+                        default=None,
+                        help='Set BSSID for OPEN AP')
+
+    owe_transition_group.add_argument('--transition-ssid',
+                        dest='owe_transition_ssid',
+                        type=str,
+                        default=None,
+                        help='Set SSID for OPEN AP')
+
     eap_group = parser.add_argument_group(
                         'EAP Options',
                         'Only applicable if --auth wpa is used',
@@ -618,7 +645,7 @@ def set_options():
                                 '--autocrack is used',
     )
 
-    eap_group.add_argument('--remote-cracking-rig',
+    autocrack_group.add_argument('--remote-cracking-rig',
                            dest='remote_rig',
                            type=str,
                            metavar='server:port',

--- a/core/hostapd_config.py
+++ b/core/hostapd_config.py
@@ -30,6 +30,13 @@ class HostapdConfig(object):
         if options['wmm']:
             configs['wmm'] = self.populate_wmm(settings, options)
 
+        if options['auth'] == 'owe':
+            configs['owe'] = self.populate_owe(settings, options)
+
+        if options['auth'] == 'owe-transition':
+            configs['owe_transition'] = self.populate_owe_transition(settings, options)
+            configs['populate_owe_transition_open_bss'] = self.populate_owe_transition_open_bss(settings, options)
+
         self.dict = configs
 
         if options['debug']:
@@ -325,7 +332,10 @@ class HostapdConfig(object):
 
 
         if options['cloaking'] is None:
-            general_configs['ignore_broadcast_ssid'] = settings.dict['core']['hostapd']['general']['ignore_broadcast_ssid']
+            if options['auth'] == 'owe-transition':
+                general_configs['ignore_broadcast_ssid'] = settings.dict['core']['hostapd']['owe_transition']['owe_transition_ignore_broadcast_ssid']
+            else:
+                general_configs['ignore_broadcast_ssid'] = settings.dict['core']['hostapd']['general']['ignore_broadcast_ssid']
 
         else:
 
@@ -459,7 +469,15 @@ class HostapdConfig(object):
             general_configs['known_beacons'] = settings.dict['core']['hostapd']['general']['known_beacons']
 
         if options['pmf'] is None:
-            general_configs['ieee80211w'] = settings.dict['core']['hostapd']['general']['ieee80211w']
+            if options['auth'] == 'owe':
+                general_configs['ieee80211w'] = settings.dict['core']['hostapd']['owe']['owe_ieee80211w']
+            elif options['auth'] == 'owe-transition':
+                general_configs['ieee80211w'] = settings.dict['core']['hostapd']['owe_transition']['owe_transition_ieee80211w']
+            #if options['auth'] == 'owe-psk':
+            #    general_configs['ieee80211w'] = settings.dict['core']['hostapd']['owe']['owe_psk_ieee80211w']
+
+            else:
+                general_configs['ieee80211w'] = settings.dict['core']['hostapd']['general']['ieee80211w']
         elif options['pmf'] == 'disable':
             general_configs['ieee80211w'] = '0'
         elif options['pmf'] == 'enable':
@@ -471,3 +489,67 @@ class HostapdConfig(object):
 
 
         return general_configs
+
+    def populate_owe(self, settings, options):
+
+        owe_configs = {
+                
+            'wpa' : settings.dict['core']['hostapd']['owe']['wpa'],
+            'wpa_key_mgmt' : settings.dict['core']['hostapd']['owe']['wpa_key_mgmt'],
+            'rsn_pairwise' : settings.dict['core']['hostapd']['owe']['rsn_pairwise'],
+        }
+
+        return owe_configs
+
+    def populate_owe_transition(self, settings, options):
+
+        owe_transition_configs = {
+
+            'wpa' : settings.dict['core']['hostapd']['owe_transition']['wpa'],
+            'wpa_key_mgmt' : settings.dict['core']['hostapd']['owe_transition']['wpa_key_mgmt'],
+            'rsn_pairwise' : settings.dict['core']['hostapd']['owe_transition']['rsn_pairwise'],
+        }
+
+        if options['owe_transition_ssid'] is None:
+            owe_transition_configs['owe_transition_ssid'] = '"{}"'.format(settings.dict['core']['hostapd']['owe_transition']['owe_transition_ssid'])
+        else:
+            owe_transition_configs['owe_transition_ssid'] = '"{}"'.format(options['owe_transition_ssid'])
+
+        if options['owe_transition_bssid'] is None:
+            owe_transition_configs['owe_transition_bssid'] = settings.dict['core']['hostapd']['owe_transition']['owe_transition_bssid']
+        else:
+            owe_transition_configs['owe_transition_bssid'] = options['owe_transition_ssid']
+
+        return owe_transition_configs
+
+    def populate_owe_transition_open_bss(self, settings, options):
+
+        owe_transition_open_bss_configs = {
+
+            'bss' : '{}_0'.format(options['interface']),
+        }
+
+        # set bssid and ssid values for open BSS ------------------
+        if options['owe_transition_ssid'] is None:
+            owe_transition_open_bss_configs['ssid'] = settings.dict['core']['hostapd']['owe_transition']['owe_transition_ssid']
+        else:
+            owe_transition_open_bss_configs['ssid'] = options['owe_transition_ssid']
+
+        if options['owe_transition_bssid'] is None:
+            owe_transition_open_bss_configs['bssid'] = settings.dict['core']['hostapd']['owe_transition']['owe_transition_bssid']
+        else:
+            owe_transition_open_bss_configs['bssid'] = options['owe_transition_ssid']
+
+        # set owe_transition_bssid and owe_transition_ssid values for open BSS ---
+        if options['essid'] is None:
+            owe_transition_open_bss_configs['owe_transition_ssid'] = '"{}"'.format(settings.dict['core']['hostapd']['general']['ssid'])
+        else:
+            owe_transition_open_bss_configs['owe_transition_ssid'] = '"{}"'.format(options['essid'])
+
+        if options['bssid'] is None:
+            owe_transition_open_bss_configs['owe_transition_bssid'] = settings.dict['core']['hostapd']['general']['bssid']
+        else:
+            owe_transition_open_bss_configs['owe_transition_bssid'] = options['bssid']
+
+        return owe_transition_open_bss_configs
+

--- a/settings/core/hostapd.ini
+++ b/settings/core/hostapd.ini
@@ -186,6 +186,41 @@ auth_algs=3
 wpa=2
 
 ; ----------------------------------------------------------------------------
-; The following WPA configs can only set using this confg file:
+; The following WPA configs can only set using this file:
 
 wpa_pairwise=TKIP CCMP
+
+
+[owe]
+; ----------------------------------------------------------------------------
+; The following OWE configs can only set using this file:
+
+wpa_key_mgmt=OWE
+rsn_pairwise=CCMP
+wpa=2
+
+; PMF
+owe_ieee80211w=2
+
+[owe_transition]
+
+; The following values can be set using both the cli and this config file. 
+; If both are used, the cli takes precedence.
+owe_transition_bssid=fe:e1:de:ce:a5:ed
+owe_transition_ssid=remmahpae
+
+; ----------------------------------------------------------------------------
+; The following OWE Transition Mode configs can only set using this file:
+
+wpa_key_mgmt=OWE
+rsn_pairwise=CCMP
+wpa=2
+
+; PMF
+owe_transition_ieee80211w=2
+
+; cloaking 
+owe_transition_ignore_broadcast_ssid=1
+
+
+


### PR DESCRIPTION
Added support for rogue AP attacks against networks that use OWE and OWE Transition Mode. Resolves #100. Resolves #101. 