### PR TITLE
EAP password spray method: small fix for bytes error

### DIFF
--- a/core/wpa_supplicant.py
+++ b/core/wpa_supplicant.py
@@ -14,7 +14,7 @@ class WPA_Supplicant(object):
 
         p = subprocess.Popen(['wpa_supplicant', '-i', self.interface, '-c', self.conf.path], shell=False, stdout=subprocess.PIPE, preexec_fn=os.setsid)
         while True:
-            line = p.stdout.readline()
+            line = p.stdout.readline().decode("utf-8")
             print(line.replace('%s:' % self.interface, '[%s]' % self.interface), end=' ')
             if 'CTRL-EVENT-EAP-SUCCESS' in line:
                 p.kill()


### PR DESCRIPTION
Hi Gabriel,

during my latest usage of EAP password spray I encountered the following:

```
./eaphammer --eap-spray --interface-pool wlan0 --essid 'someESSID' --password Password123 --user-list /root/users.txt 
[.. snip ..]
[*] Root privs confirmed! 8D
[wlan0] Trying credentials: test:Password123@someESSID
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/root/Downloads/eaphammer/core/eap_spray/worker.py", line 34, in _start
    if wpa_supplicant.test_creds():
  File "/root/Downloads/eaphammer/core/wpa_supplicant.py", line 18, in test_creds
    print(line.replace('%s:' % self.interface, '[%s]' % self.interface), end=' ')
TypeError: a bytes-like object is required, not 'str'
```

Small fix is attached. Thank you for building and maintaining this tool!
