### PR TITLE
Hostapd ctrl_interfac abspath fix

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -153,3 +153,6 @@ Added beacon forger for executing known SSID bursts
 
 1.12.0 - Gabriel Ryan <gryan@specterops.io>
 Added --known-ssids flag that can be used instead of --known-ssids-file flag.
+
+1.12.1 - Gabriel Ryan <gabriel@specterops.io>
+Hostapd ctrl_interface name randomly generated to support multiple concurrent eaphammer instances, given absolute path

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ by Gabriel Ryan ([s0lst1c3](https://twitter.com/s0lst1c3))(gabriel[at]specterops
 
 [![Foo](https://rawcdn.githack.com/toolswatch/badges/8bd9be6dac2a1d445367001f2371176cc50a5707/arsenal/usa/2017.svg)](https://www.blackhat.com/us-17/arsenal.html#eaphammer)
 
-Current release: [v1.12.0](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.12.0)
+Current release: [v1.12.1](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.12.0)
 
 Supports _Python 3.5+_.
 

--- a/__version__.py
+++ b/__version__.py
@@ -1,5 +1,5 @@
-__version__ = '1.12.0'
+__version__ = '1.12.1'
 __codename__ = 'Power Overwhelming'
 __author__ = '@s0lst1c3'
-__contact__ = 'gryan@specterops.io'
+__contact__ = 'gabriel@specterops.io'
 __tagline__ = 'Rogue AP attacks for operators.'

--- a/core/hostapd_config.py
+++ b/core/hostapd_config.py
@@ -491,7 +491,8 @@ class HostapdConfig(object):
 
         general_configs['country_code'] = settings.dict['core']['hostapd']['general']['country_code']
 
-        general_configs['ctrl_interface'] = settings.dict['core']['hostapd']['general']['ctrl_interface']
+        #general_configs['ctrl_interface'] = settings.dict['core']['hostapd']['general']['ctrl_interface']
+        general_configs['ctrl_interface'] = settings.dict['paths']['hostapd']['ctrl_interface']
 
         general_configs['ctrl_interface_group'] = settings.dict['core']['hostapd']['general']['ctrl_interface_group']
 

--- a/settings/paths.py
+++ b/settings/paths.py
@@ -7,9 +7,9 @@ from datetime import datetime
 
 class OutputFile(object):
 
-    def __init__(self, name='', ext=''):
+    def __init__(self, name='', ext='', length=32):
         datestring = datetime.strftime(datetime.now(), '%Y-%m-%d-%H-%M-%S')
-        randstring = ''.join(random.choice(string.ascii_letters+string.digits) for _ in range(32))
+        randstring = ''.join(random.choice(string.ascii_letters+string.digits) for _ in range(length))
         self.str = ''
         if name != '':
             self.str += '%s-' % name
@@ -28,6 +28,7 @@ ROOT_DIR = os.path.split(os.path.dirname(os.path.abspath(__file__)))[0]
 CONF_DIR = os.path.join(ROOT_DIR, 'settings')
 SAVE_DIR = os.path.join(ROOT_DIR, 'saved-configs')
 LOG_DIR = os.path.join(ROOT_DIR, 'logs')
+RUN_DIR = os.path.join(ROOT_DIR, 'run')
 SCRIPT_DIR = os.path.join(ROOT_DIR, 'scripts')
 DB_DIR = os.path.join(ROOT_DIR, 'db')
 TMP_DIR = os.path.join(ROOT_DIR, 'tmp')
@@ -81,6 +82,9 @@ HCXPCAPTOOL_OFILE = os.path.join(TMP_DIR, output_file)
 HOSTAPD_BIN = os.path.join(HOSTAPD_DIR, 'hostapd-eaphammer')
 HOSTAPD_LIB = os.path.join(HOSTAPD_DIR, 'libhostapd-eaphammer.so')
 HOSTAPD_LOG = os.path.join(LOG_DIR, 'hostapd-eaphammer.log')
+#output_file = 'hostapd-control-interface' # fuckit
+output_file = OutputFile(name='ctrl-iface', length=8).string()
+HOSTAPD_CTRL_INTERFACE = os.path.join(RUN_DIR, output_file)
 
 # eap_spray paths
 EAP_SPRAY_LOG = os.path.join(LOG_DIR, 'eap_spray.log')
@@ -191,6 +195,7 @@ paths = {
         'phase1_accounts' : PHASE1_ACCOUNTS,
         'phase2_accounts' : PHASE2_ACCOUNTS,
         'fifo' : FIFO_PATH,
+        'ctrl_interface' : HOSTAPD_CTRL_INTERFACE,
         'conf' : HOSTAPD_CONF,
         'save' : HOSTAPD_SAVE,
         'mac_whitelist' : HOSTAPD_MAC_WHITELIST,


### PR DESCRIPTION
Hostapd ctrl_interface name randomly generated to support multiple concurrent eaphammer instances, given absolute path