### PR TITLE
Fixed Kali setup scripts, deps file

### DIFF
--- a/kali-dependencies.txt
+++ b/kali-dependencies.txt
@@ -7,3 +7,4 @@ libnl-genl-3-dev
 libcurl4-openssl-dev
 zlib1g-dev
 libpcap-dev
+python3-pip

--- a/kali-setup
+++ b/kali-setup
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 import os
+import sys
 
 from settings import settings
+
+def exit_if_not_root():
+
+    if os.getuid() != 0:
+        sys.exit("[!} Error: this script must be run as root.")
 
 def read_deps_file(deps_file):
     with open(deps_file) as fd:
         return ' '.join([ line.strip() for line in fd ])
 
 if __name__ == '__main__':
+
+    exit_if_not_root()
                     
 
     default_wordlist = os.path.join(settings.dict['paths']['directories']['wordlists'], settings.dict['core']['eaphammer']['general']['default_wordlist'])
@@ -25,19 +33,10 @@ if __name__ == '__main__':
     openssl_bin = settings.dict['paths']['openssl']['bin']
     dh_file = settings.dict['paths']['certs']['dh']
 
-    if input('Do you want update your package list ("apt -y update")(recommended)? [y/N]: ').lower() == 'y':
-        print('\n[*] Downloading package lists from kali repositories...\n')
-        os.system('apt -y update')
-        print('\n[*] complete!\n')
-
+    if input('Important: it is highly recommended that you run "apt -y update" and "apt -y upgrade" prior to running this setup script. Do you wish to proceed? Enter [y/N]: ').lower() != 'y':
+        sys.exit('Aborting.')
     print()
 
-    if input('Do you want upgrade your installed packages ("apt -y upgrade")(recommended)? [y/N]: ').lower() == 'y':
-        print('\n[*] Performing upgrade...\n')
-        os.system('apt -y upgrade')
-        print('\n[*] complete!\n')
-
-    print()
 
     print('\n[*] Removing stub files...\n')
     os.system('find {} -type f -name \'stub\' -exec rm -f {{}} +'.format(root_dir))


### PR DESCRIPTION
- kali-setup - Removed calls to apt-update, apt-upgrade and replaced with warning (apt-listchanges is called by default on latest Kali version, and is not meant for unattended use).
- kali-dependencies.txt - Added python3-pip as explicit dependency.

Resolves #146
Resolves #145|
Resolves #130