### PR TITLE
Fix gevent python 3.8 related fuckery

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -181,3 +181,5 @@ Resolve issue #59 by fixing Python3 unicode bullshit. - (Credit goes to github.c
 1.13.4 - Gabriel Ryan <gabriel@solstice.sh>
 Resolve issue #59 by fixing Python3 unicode bullshit.  :D 
 
+1.13.5 - Gabriel Ryan <gabriel@solstice.sh>
+Fixed gevent / python 3.9 related fuckery.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ by Gabriel Ryan ([s0lst1c3](https://twitter.com/s0lst1c3))(gabriel[at]solstice|d
 
 [![Foo](https://rawcdn.githack.com/toolswatch/badges/8bd9be6dac2a1d445367001f2371176cc50a5707/arsenal/usa/2017.svg)](https://www.blackhat.com/us-17/arsenal.html#eaphammer)
 
-Current release: [v1.13.4](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.13.4)
+Current release: [v1.13.5](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.13.5)
 
 Supports _Python 3.5+_.
 
@@ -79,7 +79,7 @@ Features
 - Fast and automated PMKID attacks against PSK networks using hcxtools
 - Password spraying across multiple usernames against a single ESSID
 
-### New (as of Version 1.13.4)(latest): 
+### New (as of Version 1.13.5)(latest): 
 EAPHammer now has a modular captive portal with keylogging and payload delivery capabilities, as well as an integrated website cloaner for easily creating portal modules.
 
 ### WPA/2-PSK handshake captures (added as for version 1.7.0)

--- a/__version__.py
+++ b/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '1.13.4'
+__version__ = '1.13.5'
 __codename__ = 'Power Overwhelming'
 __author__ = '@s0lst1c3'
 __contact__ = 'gabriel<<at>>solstice(doT)sh'

--- a/eaphammer
+++ b/eaphammer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.8
 
 import argparse
 import cert_wizard

--- a/pip.req
+++ b/pip.req
@@ -1,3 +1,4 @@
+gevent>=1.5.0
 tqdm
 pem
 pyOpenSSL
@@ -9,3 +10,4 @@ requests_html
 pywebcopy
 jinja2
 flask-cors
+flask-socketio


### PR DESCRIPTION
Fixed gevent issues by modifying eaphammer to explicitly call Python 3.8. Modified pip.req to… require a version of gevent greater than 1.5.0.