### PR TITLE
Fix pywebcopy running infinitely

### DIFF
--- a/pip.req
+++ b/pip.req
@@ -7,7 +7,7 @@ lxml
 beautifulsoup4
 pyquery
 requests_html
-pywebcopy
+git+git://github.com/davidwgrossman/pywebcopy
 jinja2
 flask-cors
 flask-socketio


### PR DESCRIPTION
The pywebcopy library is running infinitely because of a deadlock in the concurrent library. 
@davidwgrossman rewrote a part of it to remove the multithreading part which is why I changed the library origin from the official repo to the fork of David.

Thus the cloning part will be slower (since running on a single thread) but will work. :)