### PR TITLE
`sockios.h` wasn't  included

### DIFF
--- a/local/hcxdumptool/hcxdumptool.c
+++ b/local/hcxdumptool/hcxdumptool.c
@@ -47,6 +47,7 @@
 #include "include/pcap.c"
 #include "include/strings.c"
 #include "include/hashops.c"
+#include <linux/sockios.h>
 /*===========================================================================*/
 /* global var */
 


### PR DESCRIPTION
Using `kali-setup` script in a Debian 11 (Testing), error:
<samp>error: ‘SIOCGSTAMP’ undeclared (first use in this function); did you mean ‘SIOCGARP’</samp>

Fix: `sockios.h` wasn't  included