### PR TITLE
fixing-missing-parentheses-on-print

### DIFF
--- a/payload_generator
+++ b/payload_generator
@@ -46,4 +46,4 @@ if __name__ == '__main__':
 
     print
     print
-    print (s.execute())
+    print(s.execute())

--- a/payload_generator
+++ b/payload_generator
@@ -46,4 +46,4 @@ if __name__ == '__main__':
 
     print
     print
-    print s.execute()
+    print (s.execute())


### PR DESCRIPTION
It fixes the following error when running the payload_generator script:
... 
```
/eaphammer/payload_generator", line 49
    print s.execute()
    ^^^^^^^^^^^^^^^^^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
```
