### PR TITLE
Fix --hostile-portal errors with responder and add ESSID Stripping feature

### DIFF
--- a/ESSIDStripping.md
+++ b/ESSIDStripping.md
@@ -4,30 +4,34 @@ Add a non-printable UTF8 character to the AP ESSID to avoid new security setting
 
 With this attack, the AP name is the same for the client, but Windows detects the full name as a new one, as it sees the non-printable characters. Then, the client asks for the username, password, etc. when logging in. Like a new network.
 
-In this case we use '/r' because is not showed by Android and it may go unnoticed as a new line in Windows, Linux and iOS.
 
-Other option is to use:
-- '/t' for a tab
-- '/n' for a enter, like '\r'
+The options are:
+- '\r' for a new line.
+- '\t' for a tab.
+- '\n' for a enter, like '\r'.
+- '\x20' for a space, like adding a white space after the SSID option using quotes.
 
-If you want to change it you can modify the file: 
-"eaphammer/core/hostapd_config.py"
 
-## Attacking with Eaphammer
+## Attacking with original Eaphammer (only space)
 
-### Attack on windows
+```bash
+python3 ./eaphammer -i wlan3 --auth wpa-eap --essid "wifi-AP " --creds --negotiate balanced
+```
 
-### Attack on linux
+## Attacking with modified Eaphammer
 
-### Attack on Android
+An example using the  `--stripping '\r'`  parameter is shown below. In this case we use '\r' because is not showed by Android and it may go unnoticed as a new line in Windows, Linux and iOS.
 
-### Attack on iOS
+
+```bash
+python3 ./eaphammer -i wlan0 --auth wpa-eap --essid wifi-AP --creds --negotiate balanced --essid-stripping '\r'
+```
 
 ## Attacking manually using hostapd
 
 We only have to use the UTF8 essid options, and use the P options in the essid2 in the hostapd.conf file:
 ``` bash
-ssid2=P"wifi-AP/n"
+ssid2=P"wifi-AP\x20"
 utf8_ssid=1
 ```
 

--- a/ESSIDStripping.md
+++ b/ESSIDStripping.md
@@ -1,0 +1,38 @@
+# ESSID Stripping
+
+Add a non-printable UTF8 character to the AP ESSID to avoid new security settings on WiFi clients, such as Microsoft. This security configuration stores the information of the old connections and notifies if there are any changes, blocking the automatic connections and not allowing access to the network. In addition, the user's credentials could be obtained in case the computer uses client certificate or computer credentials in the domain, because for Windows is a new network.
+
+With this attack, the AP name is the same for the client, but Windows detects the full name as a new one, as it sees the non-printable characters. Then, the client asks for the username, password, etc. when logging in. Like a new network.
+
+In this case we use '/r' because is not showed by Android and it may go unnoticed as a new line in Windows, Linux and iOS.
+
+Other option is to use:
+- '/t' for a tab
+- '/n' for a enter, like '\r'
+
+If you want to change it you can modify the file: 
+"eaphammer/core/hostapd_config.py"
+
+## Attacking with Eaphammer
+
+### Attack on windows
+
+### Attack on linux
+
+### Attack on Android
+
+### Attack on iOS
+
+## Attacking manually using hostapd
+
+We only have to use the UTF8 essid options, and use the P options in the essid2 in the hostapd.conf file:
+``` bash
+ssid2=P"wifi-AP/n"
+utf8_ssid=1
+```
+
+# Refs
+
+- https://aireye.tech/2021/09/13/the-ssid-stripping-vulnerability-when-you-dont-see-what-you-get/
+
+- https://w1.fi/cgit/hostap/plain/hostapd/hostapd.conf

--- a/core/cli.py
+++ b/core/cli.py
@@ -42,6 +42,7 @@ BASIC_OPTIONS = [
     'lport',
     'karma',
     'mana',
+    'stripping',
     'loud',
     'create_template',
     'delete_template',
@@ -456,6 +457,12 @@ def set_options():
                                     dest='karma',
                                     action='store_true',
                                     help='Enable karma.')
+
+
+    access_point_group.add_argument('--stripping',
+                                    dest='stripping',
+                                    action='store_true',
+                                    help='Enable ESSID Stripping.')
 
     access_point_group.add_argument('--mac-whitelist',
                                     dest='mac_whitelist',

--- a/core/cli.py
+++ b/core/cli.py
@@ -42,7 +42,7 @@ BASIC_OPTIONS = [
     'lport',
     'karma',
     'mana',
-    'stripping',
+    'essid_stripping',
     'loud',
     'create_template',
     'delete_template',
@@ -459,10 +459,12 @@ def set_options():
                                     help='Enable karma.')
 
 
-    access_point_group.add_argument('--stripping',
-                                    dest='stripping',
-                                    action='store_true',
-                                    help='Enable ESSID Stripping.')
+    access_point_group.add_argument('--essid-stripping',
+                                    dest='essid_stripping',
+                                    type=str,
+                                    choices=['\\r', '\\n', '\\t', '\\x20'],
+                                    default=None,
+                                    help='Enable ESSID Stripping adding \\r.')
 
     access_point_group.add_argument('--mac-whitelist',
                                     dest='mac_whitelist',

--- a/core/hostapd_config.py
+++ b/core/hostapd_config.py
@@ -361,6 +361,14 @@ class HostapdConfig(object):
         if options['essid'] is None:
             general_configs['ssid'] = settings.dict['core']['hostapd']['general']['ssid']
         else:
+            if options['stripping']:
+                general_configs['ssid'] = options['essid'] 
+                # Add UTF8 and ssid2=P"wifi-AP\n"
+                general_configs['ssid2'] = "P\"" + options['essid'] + "\\r\""
+                general_configs['utf8_ssid'] = 1
+            else:
+                general_configs['ssid'] = options['essid']
+
             general_configs['ssid'] = options['essid']
 
         if options['bssid'] is None:

--- a/core/hostapd_config.py
+++ b/core/hostapd_config.py
@@ -361,10 +361,11 @@ class HostapdConfig(object):
         if options['essid'] is None:
             general_configs['ssid'] = settings.dict['core']['hostapd']['general']['ssid']
         else:
-            if options['stripping']:
+            if options['essid_stripping']:
+                UTF8_char = options['essid_stripping']
                 general_configs['ssid'] = options['essid'] 
                 # Add UTF8 and ssid2=P"wifi-AP\n"
-                general_configs['ssid2'] = "P\"" + options['essid'] + "\\r\""
+                general_configs['ssid2'] = "P\"" + options['essid'] + UTF8_char +"\""
                 general_configs['utf8_ssid'] = 1
             else:
                 general_configs['ssid'] = options['essid']

--- a/core/responder.py
+++ b/core/responder.py
@@ -18,7 +18,7 @@ class Responder(object):
     def start(self, iface):
 
         responder_bin = settings.dict['paths']['responder']['bin']
-        self.process = subprocess.Popen([responder_bin, '-wrf', '--lm', '-I', iface])
+        self.process = subprocess.Popen([responder_bin, '-wF', '-I', iface])
 
     def stop(self):
 

--- a/local/hostapd-eaphammer/hostapd/hostapd.conf
+++ b/local/hostapd-eaphammer/hostapd/hostapd.conf
@@ -85,7 +85,8 @@ ctrl_interface_group=0
 ##### IEEE 802.11 related configuration #######################################
 
 # SSID to be used in IEEE 802.11 management frames
-ssid=test
+ssid2=test
+utf8_ssid=1
 # Alternative formats for configuring SSID
 # (double quoted string, hexdump, printf-escaped string)
 #ssid2="test"

--- a/pip.req
+++ b/pip.req
@@ -1,6 +1,6 @@
 gevent>=1.5.0
 tqdm
-pem
+pem==21.2.0
 pyOpenSSL
 scapy
 lxml

--- a/settings/core/Responder.ini
+++ b/settings/core/Responder.ini
@@ -12,6 +12,10 @@ HTTP = Off
 HTTPS = On
 DNS = Off
 LDAP = On
+RDP = On
+DCERPC = On
+WINRM = On
+SNMP = Off
 
 ; Custom challenge. 
 ; Use "Random" for generating a random challenge for each requests (Default)

--- a/settings/core/Responder.ini
+++ b/settings/core/Responder.ini
@@ -16,6 +16,7 @@ RDP = On
 DCERPC = On
 WINRM = On
 SNMP = Off
+MQTT = Off
 
 ; Custom challenge. 
 ; Use "Random" for generating a random challenge for each requests (Default)


### PR DESCRIPTION
This pull request aims to fix errors encountered with the 'hostile-portal' module in Responder and introduce a new feature called ESSID Stripping. The proposed changes include bug fixes, improvements, and the addition of the ESSID Stripping functionality.

I have created a markdown talking about ESSID Stripping and have written an article at https://r4ulcl.com/posts/essid-stripping