### PR TITLE
Fix build issues - Sept 22nd 2024

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -183,3 +183,11 @@ Resolve issue #59 by fixing Python3 unicode bullshit.  :D
 
 1.13.5 - Gabriel Ryan <gabriel@solstice.sh>
 Fixed gevent / python 3.9 related fuckery.
+
+1.14.1 - Gabriel Ryan <gabriel@transmitengage.com>
+Fixed hostapd-eaphammer_lib build issues.
+The system-wide package manager (i.e. apt) is now the single source of truth for dependencies, including Python. Sounds stupid, but realistically it's probably the most stable option until we start managing the Python portions of this thing with something that isn't archaic (like Poetry) and published as a proper PyPi package.
+Removed unused Python dependencies: jinja2, pyquery
+Added support for Python 3.12 (Credit: github.com/D3vil0p3r)
+Updated README to reflect use of apt during installation instructions (Credit: github.com/readloud)
+Added wget to dependencies (Credit: github/pes-soft)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Next run the kali-setup file as shown below to complete the eaphammer setup proc
 
 	./kali-setup
 
+ Now available with : 
+
+ ```
+sudo apt install eaphammer
+```
+or
+ ```
+sudo apt-get install eaphammer
+```
+
 To setup and execute a credential stealing evil twin attack against a WPA/2-EAP network:
 
 	# generate certificates

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ by Gabriel Ryan ([s0lst1c3](https://twitter.com/s0lst1c3))
 
 [![Foo](https://rawcdn.githack.com/toolswatch/badges/8bd9be6dac2a1d445367001f2371176cc50a5707/arsenal/usa/2017.svg)](https://www.blackhat.com/us-17/arsenal.html#eaphammer)
 
-Current release: [v1.14.0](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.14.0)
+Current release: [v1.14.1](https://github.com/s0lst1c3/eaphammer/releases/tag/v1.14.1)
 
 Supports _Python 3.9+_.
 
@@ -20,6 +20,16 @@ EAPHammer (the "Software") and associated documentation is provided “AS IS”.
 
 ## Quick Start Guide - Kali
 
+### Install using Apt
+
+```
+sudo apt update
+sudo apt upgrade
+sudo apt install eaphammer
+```
+
+### Build from source
+
 Begin by cloning the __eaphammer__ repo using the following command:
 
 	git clone https://github.com/s0lst1c3/eaphammer.git
@@ -28,15 +38,7 @@ Next run the kali-setup file as shown below to complete the eaphammer setup proc
 
 	./kali-setup
 
- Now available with : 
-
- ```
-sudo apt install eaphammer
-```
-or
- ```
-sudo apt-get install eaphammer
-```
+### Basic Usage
 
 To setup and execute a credential stealing evil twin attack against a WPA/2-EAP network:
 

--- a/__version__.py
+++ b/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '1.14.0'
+__version__ = '1.14.1'
 __codename__ = 'Final Frontier'
 __author__ = '@s0lst1c3'
 __contact__ = 'gabriel<<at>>transmitengage.com'

--- a/core/cli.py
+++ b/core/cli.py
@@ -170,7 +170,7 @@ def set_options():
                               action='store_true',
                               help=('Trigger Windows Defender on nearby '
                                     'devices by spawning an AP with SSID '
-                                    'set to C:\Temp\Invoke-Mimikatz.ps1'))
+                                    'set to C:\\Temp\\Invoke-Mimikatz.ps1'))
 
     modes_group_.add_argument('--eap-spray',
                               dest='eap_spray',

--- a/core/iw_parse/iw_parse.py
+++ b/core/iw_parse/iw_parse.py
@@ -10,7 +10,7 @@
 import re
 import subprocess
 
-VERSION_RGX = re.compile("version\s+\d+", re.IGNORECASE)
+VERSION_RGX = re.compile(r"version\s+\d+", re.IGNORECASE)
 
 def get_name(cell):
     """ Gets the name / essid of a network / cell.

--- a/core/strtobool.py
+++ b/core/strtobool.py
@@ -1,0 +1,21 @@
+_MAP = {
+    'y': True,
+    'yes': True,
+    't': True,
+    'true': True,
+    'on': True,
+    '1': True,
+    'n': False,
+    'no': False,
+    'f': False,
+    'false': False,
+    'off': False,
+    '0': False
+}
+
+
+def strtobool(value):
+    try:
+        return _MAP[str(value).lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,6 +4,28 @@ import time
 from settings import settings
 from tqdm import tqdm
 
+
+_STR2BOOL_MAP = {
+    'y': True,
+    'yes': True,
+    't': True,
+    'true': True,
+    'on': True,
+    '1': True,
+    'n': False,
+    'no': False,
+    'f': False,
+    'false': False,
+    'off': False,
+    '0': False
+}
+
+def strtobool(value):
+    try:
+        return _STR2BOOL_MAP[str(value).lower()]
+    except KeyError:
+        raise ValueError(f'"{value}" is not a valid bool value')
+
 def ip_replace_last_octet(ip_addr, new_val):
 
     return '.'.join(ip_addr.split('.')[:-1]+[new_val])

--- a/core/wskeyloggerd/app.py
+++ b/core/wskeyloggerd/app.py
@@ -25,7 +25,7 @@ from urllib.parse import quote_plus
 
 from settings import settings
 
-'''
+r'''
       .    .
           .       =O===
        . _       %- - %%%

--- a/eaphammer
+++ b/eaphammer
@@ -36,10 +36,9 @@ from __version__ import __version__, __tagline__, __author__, __contact__, __cod
 from threading import Thread
 from core.utils import ip_replace_last_octet
 from core.loader import Loader
+from core.strtobool import strtobool
 
 from core.module_maker import ModuleMaker
-
-from distutils.util import strtobool
 
 def hostile_portal():
 

--- a/eaphammer
+++ b/eaphammer
@@ -35,8 +35,8 @@ from settings import settings
 from __version__ import __version__, __tagline__, __author__, __contact__, __codename__
 from threading import Thread
 from core.utils import ip_replace_last_octet
+from core.utils import strtobool
 from core.loader import Loader
-from core.strtobool import strtobool
 
 from core.module_maker import ModuleMaker
 

--- a/kali-dependencies.txt
+++ b/kali-dependencies.txt
@@ -7,6 +7,7 @@ libnl-genl-3-dev
 libcurl4-openssl-dev
 zlib1g-dev
 libpcap-dev
+wget
 python3-pip
 python3-gevent
 python3-tqdm
@@ -18,4 +19,3 @@ python3-pywebcopy
 python3-bs4
 python3-flask-cors
 python3-flask-socketio
-

--- a/kali-dependencies.txt
+++ b/kali-dependencies.txt
@@ -8,3 +8,14 @@ libcurl4-openssl-dev
 zlib1g-dev
 libpcap-dev
 python3-pip
+python3-gevent
+python3-tqdm
+python3-pem
+python3-openssl
+python3-scapy
+python3-lxml
+python3-pywebcopy
+python3-bs4
+python3-flask-cors
+python3-flask-socketio
+

--- a/kali-setup
+++ b/kali-setup
@@ -47,10 +47,6 @@ if __name__ == '__main__':
     os.system('apt -y install %s' % read_deps_file('kali-dependencies.txt'))
     print('\n[*] complete!\n')
 
-    print('\n[*] Installing Python dependencies...\n')
-    os.system('python3 -m pip install -r pip.req')
-    print('\n[*] complete!\n')
-    
 
     print('\n[*] Downloading OpenSSL_{}...\n'.format(openssl_version.replace('.', '_')))
     os.system('wget {} -O {}/openssl.tar.gz'.format(openssl_source, local_dir))

--- a/local/hostapd-eaphammer/hostapd/config_file.c
+++ b/local/hostapd-eaphammer/hostapd/config_file.c
@@ -319,8 +319,11 @@ static int hostapd_config_read_maclist(const char *fname,
 
 		// increment to the first null terminator or instance of whitespace
 		// (whichever comes first) 
-		addr_str[18] = ""; // 18 == length of ascii mac representation + null terminator
-		mask_str[18] = "ff:ff:ff:ff:ff:ff"; // 18 == length of ascii mac representation + null terminator
+        char addr_str[19]; // 19 == length of ascii mac representation + null terminator
+        char mask_str[19]; // 19 == length of ascii mac representation + null terminator
+        strcpy(addr_str, ""); // copy empty string into addr_str
+        strcpy(mask_str, "ff:ff:ff:ff:ff:ff"); // copy string into mask_str
+
 		addr_str_index = 0;
 		mask_str_index = 0;
 		while (*pos != '\0' && *pos != ' ' && *pos != '\t') {

--- a/local/hostapd-eaphammer/src/eap_server/eap_server_gtc.c
+++ b/local/hostapd-eaphammer/src/eap_server/eap_server_gtc.c
@@ -11,6 +11,10 @@
 #include "common.h"
 #include "eap_i.h"
 
+#ifdef EAPHAMMER
+#include "eaphammer_wpe/eaphammer_wpe.h"
+#endif
+
 
 struct eap_gtc_data {
 	enum { CONTINUE, SUCCESS, FAILURE } state;

--- a/local/hostapd-eaphammer/src/eap_server/eap_server_md5.c
+++ b/local/hostapd-eaphammer/src/eap_server/eap_server_md5.c
@@ -13,8 +13,13 @@
 #include "eap_i.h"
 #include "eap_common/chap.h"
 
+#ifdef EAPHAMMER
+#include "eaphammer_wpe/eaphammer_wpe.h"
+#endif
+
 
 #define CHALLENGE_LEN 16
+
 
 struct eap_md5_data {
 	u8 challenge[CHALLENGE_LEN];

--- a/parrot-dependencies.txt
+++ b/parrot-dependencies.txt
@@ -8,3 +8,14 @@ libcurl4-openssl-dev
 zlib1g-dev
 libpcap-dev
 python3-pip
+python3-gevent
+python3-tqdm
+python3-pem
+python3-openssl
+python3-scapy
+python3-lxml
+python3-pywebcopy
+python3-bs4
+python3-flask-cors
+python3-flask-socketio
+

--- a/parrot-setup
+++ b/parrot-setup
@@ -47,12 +47,6 @@ if __name__ == '__main__':
     os.system('apt -y install %s -t parrot-backports' % read_deps_file('parrot-dependencies.txt'))
     print('\n[*] complete!\n')
 
-
-    print('\n[*] Installing Python dependencies...\n')
-    os.system('python3 -m pip install -r pip.req')
-    print('\n[*] complete!\n')
-    
-
     print('\n[*] Downloading OpenSSL_{}...\n'.format(openssl_version.replace('.', '_')))
     os.system('wget {} -O {}/openssl.tar.gz'.format(openssl_source, local_dir))
     print('\n[*] complete!\n')

--- a/pip.req
+++ b/pip.req
@@ -1,13 +1,10 @@
 gevent>=1.5.0
 tqdm
-pem==21.2.0
+pem>=21.2.0
 pyOpenSSL
 scapy
 lxml
 beautifulsoup4
-pyquery
-requests_html
 pywebcopy
-jinja2
 flask-cors
 flask-socketio

--- a/raspbian-dependencies.txt
+++ b/raspbian-dependencies.txt
@@ -8,3 +8,14 @@ libcurl4-openssl-dev
 zlib1g-dev
 libpcap-dev
 python3-pip
+python3-gevent
+python3-tqdm
+python3-pem
+python3-openssl
+python3-scapy
+python3-lxml
+python3-pywebcopy
+python3-bs4
+python3-flask-cors
+python3-flask-socketio
+

--- a/raspbian-setup
+++ b/raspbian-setup
@@ -48,11 +48,6 @@ if __name__ == '__main__':
     os.system('apt -y install %s' % read_deps_file('raspbian-dependencies.txt'))
     print('\n[*] complete!\n')
 
-    print('\n[*] Installing Python dependencies...\n')
-    os.system('python3 -m pip install -r pip.req')
-    print('\n[*] complete!\n')
-    
-
     print('\n[*] Downloading OpenSSL_{}...\n'.format(openssl_version.replace('.', '_')))
     os.system('wget {} -O {}/openssl.tar.gz'.format(openssl_source, local_dir))
     print('\n[*] complete!\n')

--- a/ubuntu-unattended-setup
+++ b/ubuntu-unattended-setup
@@ -44,11 +44,6 @@ if __name__ == '__main__':
     os.system('export DEBIAN_FRONTEND=noninteractive && apt -yq install %s' % read_deps_file('kali-dependencies.txt'))
     print('\n[*] complete!\n')
 
-    print('\n[*] Installing Python dependencies...\n')
-    os.system('python3 -m pip install -r pip.req')
-    print('\n[*] complete!\n')
-    
-
     print('\n[*] Downloading OpenSSL_{}...\n'.format(openssl_version.replace('.', '_')))
     os.system('wget {} -O {}/openssl.tar.gz'.format(openssl_source, local_dir))
     print('\n[*] complete!\n')


### PR DESCRIPTION
Bug and build fixes:

- Fixed hostapd-eaphammer_lib build issues.
- The system-wide package manager (i.e. apt) is now the single source of truth for dependencies, including Python. Sounds stupid, but realistically it's probably the most stable option until we start managing the Python portions of this thing with something that isn't archaic (like Poetry) and published as a proper PyPi package.
- Removed unused Python dependencies: jinja2, pyquery
- Added support for Python 3.12 (Credit: github.com/D3vil0p3r)
- Updated README to reflect use of apt during installation instructions (Credit: github.com/readloud)
- Added wget to dependencies (Credit: github/pes-soft)

Resolutions:

- Fixes #207
- Fixes #209
- Fixes #217
- Fixes #218
- Fixes #219
