### PR TITLE
Fix TMP directory to the system tmp folder

### DIFF
--- a/settings/paths.py
+++ b/settings/paths.py
@@ -2,6 +2,7 @@ import os
 import json
 import random
 import string
+import tempfile
 
 from datetime import datetime
 
@@ -31,7 +32,7 @@ LOG_DIR = os.path.join(ROOT_DIR, 'logs')
 RUN_DIR = os.path.join(ROOT_DIR, 'run')
 SCRIPT_DIR = os.path.join(ROOT_DIR, 'scripts')
 DB_DIR = os.path.join(ROOT_DIR, 'db')
-TMP_DIR = os.path.join(ROOT_DIR, 'tmp')
+TMP_DIR = tempfile.gettempdir()
 WORDLIST_DIR = os.path.join(ROOT_DIR, 'wordlists')
 LOCAL_DIR = os.path.join(ROOT_DIR, 'local')
 HOSTAPD_DIR = os.path.join(LOCAL_DIR, 'hostapd-eaphammer', 'hostapd')


### PR DESCRIPTION
Hey @s0lst1c3 , some Linux distros, like NixOS, cannot use the current temporary directory inside the eaphammer installation directory because of its readonly nature (as it should be).

Since the mentioned TMPDIR is intended for temporary files, the standard approach would be to use the system temp directory in `/tmp`. Files in `/tmp` are cleaned at each reboot.

It allows eaphammer to work also on NixOS and similar distros.

Would you like to create a minor version update tag for this (like 1.14.2)? So I can create Eaphammer Nix package: https://github.com/NixOS/nixpkgs/pull/344298